### PR TITLE
Guides categories

### DIFF
--- a/docs/how-to-docker.md
+++ b/docs/how-to-docker.md
@@ -52,6 +52,11 @@ $ docker system prune
 $ docker system prune -a --volumes
 ```
 
+To check the logs of the container, run the following command:
+```bash
+$ docker logs <CONTAINER_ID>
+```
+
 ---
 
 ## docker-compose

--- a/docs/how-to-prisma.md
+++ b/docs/how-to-prisma.md
@@ -1,3 +1,5 @@
+# How to use Prisma
+
 ###  Use case 1: You want to update the schema of your database
 
 1. Update the schema in `prisma/schema.prisma`
@@ -13,4 +15,11 @@ $ npm run prisma:migrate:dev
 # This command will generate the prisma client in the `node_modules/.prisma/client` directory
 # The generated client will be used by the app to interact with the database
 $ npm run prisma:generate
+```
+
+### Use case 2: You want to seed the database with some initial data
+Run the following command to seed the database with initial data
+```bash
+# Seed the database with initial data
+$ npm run prisma:seed
 ```

--- a/docs/how-to-prisma.md
+++ b/docs/how-to-prisma.md
@@ -1,0 +1,16 @@
+###  Use case 1: You want to update the schema of your database
+
+1. Update the schema in `prisma/schema.prisma`
+2. Run the following command to migrate the database locally
+```bash
+# Migrate the database locally to reflect the changes in the schema 
+# This command will apply the changes in the schema to the database
+$ npm run prisma:migrate:dev
+```
+3. Run the following command to generate the prisma client
+```bash
+# Generate updated prisma client to reflect the changes in the schema
+# This command will generate the prisma client in the `node_modules/.prisma/client` directory
+# The generated client will be used by the app to interact with the database
+$ npm run prisma:generate
+```

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,7 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "src",
-  "testRegex": ".*\\.spec\\.ts$",
+  "testRegex": ".*\\.(spec|test)\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },

--- a/jest.config.json
+++ b/jest.config.json
@@ -7,5 +7,6 @@
   },
   "collectCoverageFrom": ["**/*.(t|j)s"],
   "coverageDirectory": "../coverage",
-  "testEnvironment": "node"
+  "testEnvironment": "node",
+  "setupFilesAfterEnv": ["<rootDir>/test-utils/prisma/prisma-instance-mock.ts"]
 }

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,9 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "plugins": ["@nestjs/swagger"],
+    "plugins": [{
+      "name": "@nestjs/swagger"
+    }],
     "assets": [{ "include": "i18n/**/*", "watchAssets": true }]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "husky": "^9.0.11",
         "jest": "^29.5.0",
+        "jest-mock-extended": "^3.0.5",
         "lint-staged": "^15.2.2",
         "prettier": "^3.0.0",
         "prisma": "^5.10.2",
@@ -8559,6 +8560,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.5.tgz",
+      "integrity": "sha512-/eHdaNPUAXe7f65gHH5urc8SbRVWjYxBqmCgax2uqOBJy8UUcCBMN1upj1eZ8y/i+IqpyEm4Kq0VKss/GCCTdw==",
+      "dev": true,
+      "dependencies": {
+        "ts-essentials": "^7.0.3"
+      },
+      "peerDependencies": {
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -12242,6 +12256,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=3.7.0"
       }
     },
     "node_modules/ts-jest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/swagger": "^7.3.0",
         "@nestjs/terminus": "^10.2.3",
         "@prisma/client": "^5.10.2",
+        "ajv": "^8.12.0",
         "axios": "^1.6.7",
         "cache-manager": "^5.4.0",
         "class-transformer": "^0.5.1",
@@ -4816,7 +4817,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -6936,8 +6936,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -8949,8 +8948,7 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10681,7 +10679,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11004,7 +11001,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12544,7 +12540,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "husky": "^9.0.11",
     "jest": "^29.5.0",
+    "jest-mock-extended": "^3.0.5",
     "lint-staged": "^15.2.2",
     "prettier": "^3.0.0",
     "prisma": "^5.10.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "prisma:seed": "prisma db seed",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "start:migrate:prod": "prisma migrate deploy && npm run start:prod",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nestjs/swagger": "^7.3.0",
     "@nestjs/terminus": "^10.2.3",
     "@prisma/client": "^5.10.2",
+    "ajv": "^8.12.0",
     "axios": "^1.6.7",
     "cache-manager": "^5.4.0",
     "class-transformer": "^0.5.1",

--- a/prisma/migrations/20240326175939_added_guide_category_model/migration.sql
+++ b/prisma/migrations/20240326175939_added_guide_category_model/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "GuideCategory" (
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "imageUrl" TEXT NOT NULL,
+    "deleted" BOOLEAN NOT NULL DEFAULT false,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GuideCategory_pkey" PRIMARY KEY ("key")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GuideCategory_key_key" ON "GuideCategory"("key");

--- a/prisma/migrations/20240326185548_added_relation_between_categories_and_guides/migration.sql
+++ b/prisma/migrations/20240326185548_added_relation_between_categories_and_guides/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "_GuideToGuideCategory" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_GuideToGuideCategory_AB_unique" ON "_GuideToGuideCategory"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_GuideToGuideCategory_B_index" ON "_GuideToGuideCategory"("B");
+
+-- AddForeignKey
+ALTER TABLE "_GuideToGuideCategory" ADD CONSTRAINT "_GuideToGuideCategory_A_fkey" FOREIGN KEY ("A") REFERENCES "Guide"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_GuideToGuideCategory" ADD CONSTRAINT "_GuideToGuideCategory_B_fkey" FOREIGN KEY ("B") REFERENCES "GuideCategory"("key") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,9 +14,10 @@ datasource db {
 }
 
 model Guide {
-  id   String @id @default(uuid())
-  name String @unique
-  text String
+  id         String          @id @default(uuid())
+  name       String          @unique
+  text       String
+  categories GuideCategory[]
 
   primaryImages Images[] @relation(name: "GuidePrimaryImages")
   contentImages Images[] @relation(name: "GuideContentImages")
@@ -30,6 +31,18 @@ model Guide {
 
   // authorId String
   // author User @relation(fields: [authorId], references: [id])
+
+  deleted   Boolean  @default(false)
+  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+}
+
+model GuideCategory {
+  key      String @id @unique
+  name     String
+  imageUrl String
+
+  guides Guide[]
 
   deleted   Boolean  @default(false)
   updatedAt DateTime @updatedAt

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -3,6 +3,7 @@ import { Logger, Module, ModuleMetadata } from "@nestjs/common"
 import { ConfigModule } from "@nestjs/config"
 import { CitiesModule } from "../cities/cities.module"
 import { CountriesModule } from "../countries/countries.module"
+import { GuideCategoriesModule } from "../guide-categories/guide-categories.module"
 import { GuidesModule } from "../guides/guides.module"
 import { ImagesModule } from "../images/images.module"
 import { AppController } from "./app.controller"
@@ -20,7 +21,14 @@ const CONFIG_MODULES: ModuleImports = [
   CacheModule.register(),
 ]
 
-const API_MODULES: ModuleImports = [GuidesModule, ImagesModule, CountriesModule, CitiesModule, HealthCheckModule]
+const API_MODULES: ModuleImports = [
+  GuidesModule,
+  GuideCategoriesModule,
+  ImagesModule,
+  CountriesModule,
+  CitiesModule,
+  HealthCheckModule,
+]
 
 @Module({
   imports: [...CONFIG_MODULES, ...API_MODULES],

--- a/src/modules/aws-s3/types.ts
+++ b/src/modules/aws-s3/types.ts
@@ -8,8 +8,8 @@ export type PutObjectCommandOutputExtended = PutObjectCommandOutput & {
 }
 
 export class FileUploadResult {
-  key: string | null
-  url: string | null
+  key: string
+  url: string
   error: Error | null
 }
 

--- a/src/modules/cities/cities.controller.ts
+++ b/src/modules/cities/cities.controller.ts
@@ -36,6 +36,7 @@ export class CitiesController {
     description: "Page number",
   })
   @ApiOkResponse({
+    type: GetCitiesResponseDto,
     description: "Cities have been successfully received.",
   })
   @ApiBadRequestResponse({
@@ -86,6 +87,7 @@ export class CitiesController {
     description: "City id",
   })
   @ApiOkResponse({
+    type: GetCityResponseDto,
     description: "City has been successfully received.",
   })
   @ApiBadRequestResponse({

--- a/src/modules/cities/cities.service.ts
+++ b/src/modules/cities/cities.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common"
 import { plainToInstance } from "class-transformer"
-import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "../common/constants"
 import { PaginationQuery } from "../common/types"
+import { getValidPageNumber, getValidPageSize } from "../common/utils/pagination"
 import { PrismaService } from "../prisma/prisma.service"
 import { CityDto } from "./dto/city.dto"
 
@@ -13,21 +13,20 @@ export class CitiesService {
   ) {}
 
   async findAll(query: PaginationQuery): Promise<CityDto[]> {
-    let limit = query?.pageSize || DEFAULT_PAGE_SIZE
-    limit = limit > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : limit
+    const pageSize = getValidPageSize({ pageSize: query?.pageSize })
 
-    const page = query?.page || DEFAULT_PAGE
+    const page = getValidPageNumber({ page: query?.page })
 
     try {
       const results = await this.prismaService.city.findMany({
-        skip: (page - 1) * limit,
-        take: limit,
-        where: {
-          deleted: false,
-        },
         include: {
           country: true,
           images: true,
+        },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        where: {
+          deleted: false,
         },
       })
 

--- a/src/modules/cities/dto/city.dto.ts
+++ b/src/modules/cities/dto/city.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
-import { Type } from "class-transformer"
+import { Exclude, Type } from "class-transformer"
 import { Country } from "../../guides/entities/country"
 import { Image } from "../../images/entities/image.entity"
 import { City } from "../entities/city.entity"
@@ -58,4 +58,31 @@ export class CityDto extends PickType(City, ["id", "name", "description", "count
   })
   @Type(() => Image)
   images: Image[]
+
+  @ApiProperty({
+    type: Boolean,
+    description: "The deleted status of the city",
+    example: false,
+    required: true,
+  })
+  @Exclude()
+  deleted?: boolean
+
+  @ApiProperty({
+    type: Date,
+    description: "The creation date of the city",
+    example: "2021-09-28T00:00:00.000Z",
+    required: true,
+  })
+  @Exclude()
+  createdAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    description: "The update date of the city",
+    example: "2021-09-28T00:00:00.000Z",
+    required: true,
+  })
+  @Exclude()
+  updatedAt?: Date
 }

--- a/src/modules/cities/dto/city.dto.ts
+++ b/src/modules/cities/dto/city.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
-import { Exclude, Type } from "class-transformer"
+import { Type } from "class-transformer"
 import { Country } from "../../guides/entities/country"
 import { Image } from "../../images/entities/image.entity"
 import { City } from "../entities/city.entity"
@@ -20,7 +20,6 @@ export class CityDto extends PickType(City, ["id", "name", "description", "count
     type: String,
     description: "The description of the city",
     example: "Paris is the capital city of France",
-    required: true,
   })
   description: string
 
@@ -59,7 +58,4 @@ export class CityDto extends PickType(City, ["id", "name", "description", "count
   })
   @Type(() => Image)
   images: Image[]
-
-  @Exclude()
-  deleted: boolean
 }

--- a/src/modules/common/constants/pagination.ts
+++ b/src/modules/common/constants/pagination.ts
@@ -1,3 +1,6 @@
 export const MAX_PAGE_SIZE = 50
 export const DEFAULT_PAGE_SIZE = 20
+
 export const DEFAULT_PAGE = 1
+
+export const MAX_PAGE = 1000

--- a/src/modules/common/types/api-response.ts
+++ b/src/modules/common/types/api-response.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "./api-error"
 
 export type ApiResponse<TData> = {
-  data: TData
+  data: TData | null
   errors: ApiError[] | null
 }

--- a/src/modules/common/utils/pagination/index.ts
+++ b/src/modules/common/utils/pagination/index.ts
@@ -1,0 +1,2 @@
+export { getValidPageSize } from "./page-size"
+export { getValidPageNumber } from "./page-number"

--- a/src/modules/common/utils/pagination/page-number.test.ts
+++ b/src/modules/common/utils/pagination/page-number.test.ts
@@ -1,0 +1,51 @@
+import { getValidPageNumber } from "./page-number"
+
+describe("page number utils", () => {
+  describe("getValidPageNumber", () => {
+    it("should return the default page number when no page number provided", () => {
+      const pageNumber = getValidPageNumber({
+        page: undefined,
+        defaultPage: 1,
+      })
+
+      expect(pageNumber).toBe(1)
+    })
+
+    it("should return the default page number when page number is less than 0", () => {
+      const pageNumber = getValidPageNumber({
+        page: -1,
+        defaultPage: 1,
+      })
+
+      expect(pageNumber).toBe(1)
+    })
+
+    it("should return the default page number when page number is 0", () => {
+      const pageNumber = getValidPageNumber({
+        page: 0,
+        defaultPage: 1,
+      })
+
+      expect(pageNumber).toBe(1)
+    })
+
+    it("should return the default page number when page number is greater than the max page number", () => {
+      const pageNumber = getValidPageNumber({
+        page: 100,
+        defaultPage: 1,
+        maxPage: 50,
+      })
+
+      expect(pageNumber).toBe(50)
+    })
+
+    it("should return the provided page number when it is valid", () => {
+      const pageNumber = getValidPageNumber({
+        page: 20,
+        defaultPage: 1,
+      })
+
+      expect(pageNumber).toBe(20)
+    })
+  })
+})

--- a/src/modules/common/utils/pagination/page-number.ts
+++ b/src/modules/common/utils/pagination/page-number.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_PAGE, MAX_PAGE } from "../../constants"
+
+export function getValidPageNumber({
+  page,
+  defaultPage = DEFAULT_PAGE,
+  maxPage = MAX_PAGE,
+}: {
+  page: number | null | undefined
+  defaultPage?: number
+  maxPage?: number
+}) {
+  let validPage = 0
+
+  if (!page) {
+    return defaultPage
+  }
+
+  if (page <= 0) {
+    return defaultPage
+  }
+
+  validPage = page > maxPage ? maxPage : page
+
+  return validPage
+}

--- a/src/modules/common/utils/pagination/page-size.test.ts
+++ b/src/modules/common/utils/pagination/page-size.test.ts
@@ -1,0 +1,51 @@
+import { getValidPageSize } from "./page-size"
+
+describe("page size utils", () => {
+  describe("getValidPageSize", () => {
+    it("should return the default page size when no page size provided", () => {
+      const pageSize = getValidPageSize({
+        pageSize: undefined,
+        defaultPageSize: 10,
+      })
+
+      expect(pageSize).toBe(10)
+    })
+
+    it("should return the default page size when page size is less than 0", () => {
+      const pageSize = getValidPageSize({
+        pageSize: -1,
+        defaultPageSize: 10,
+      })
+
+      expect(pageSize).toBe(10)
+    })
+
+    it("should return the default page size when page size is 0", () => {
+      const pageSize = getValidPageSize({
+        pageSize: 0,
+        defaultPageSize: 10,
+      })
+
+      expect(pageSize).toBe(10)
+    })
+
+    it("should return the default page size when page size is greater than the max page size", () => {
+      const pageSize = getValidPageSize({
+        pageSize: 100,
+        defaultPageSize: 10,
+        maxPageSize: 50,
+      })
+
+      expect(pageSize).toBe(50)
+    })
+
+    it("should return the provided page size when it is valid", () => {
+      const pageSize = getValidPageSize({
+        pageSize: 20,
+        defaultPageSize: 10,
+      })
+
+      expect(pageSize).toBe(20)
+    })
+  })
+})

--- a/src/modules/common/utils/pagination/page-size.ts
+++ b/src/modules/common/utils/pagination/page-size.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from "../../constants"
+
+export function getValidPageSize({
+  pageSize,
+  defaultPageSize = DEFAULT_PAGE_SIZE,
+  maxPageSize = MAX_PAGE_SIZE,
+}: {
+  pageSize: number | null | undefined
+  defaultPageSize?: number
+  maxPageSize?: number
+}): number {
+  let validPageSize = 0
+
+  if (!pageSize) {
+    return defaultPageSize
+  }
+
+  if (pageSize <= 0) {
+    return defaultPageSize
+  }
+
+  validPageSize = pageSize > maxPageSize ? maxPageSize : pageSize
+
+  return validPageSize
+}

--- a/src/modules/countries/constants.ts
+++ b/src/modules/countries/constants.ts
@@ -1,3 +1,1 @@
-import { DEFAULT_PAGE_SIZE } from "../common/constants"
-
 export const DEFAULT_COUNTRIES_PAGE_SIZE = 30

--- a/src/modules/countries/countries.service.ts
+++ b/src/modules/countries/countries.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common"
 import { plainToInstance } from "class-transformer"
-import { DEFAULT_PAGE, MAX_PAGE_SIZE } from "../common/constants"
 import { PaginationQuery } from "../common/types"
+import { getValidPageNumber, getValidPageSize } from "../common/utils/pagination"
 import { PrismaService } from "../prisma/prisma.service"
 import { DEFAULT_COUNTRIES_PAGE_SIZE } from "./constants"
 import { CountryDto } from "./dto/country.dto"
@@ -14,15 +14,17 @@ export class CountriesService {
   ) {}
 
   async findAll(query: PaginationQuery): Promise<CountryDto[]> {
-    let limit = query?.pageSize || DEFAULT_COUNTRIES_PAGE_SIZE
-    limit = limit > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : limit
+    const pageSize = getValidPageSize({
+      pageSize: query?.pageSize,
+      defaultPageSize: DEFAULT_COUNTRIES_PAGE_SIZE,
+    })
 
-    const page = query?.page || DEFAULT_PAGE
+    const page = getValidPageNumber({ page: query?.page })
 
     try {
       const results = await this.prismaService.country.findMany({
-        skip: (page - 1) * limit,
-        take: limit,
+        skip: (page - 1) * pageSize,
+        take: pageSize,
         where: {
           deleted: false,
         },

--- a/src/modules/countries/dto/country.dto.ts
+++ b/src/modules/countries/dto/country.dto.ts
@@ -1,15 +1,77 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
+import { Type } from "class-transformer"
 import { City } from "../../cities/entities/city.entity"
 import { Image } from "../../images/entities/image.entity"
 import { Country } from "../entities/country.entity"
 
 export class CountryDto extends PickType(Country, ["id", "name", "description", "cities", "images"] as const) {
-  @ApiProperty({ type: [City] })
+  @ApiProperty({
+    type: String,
+    description: "The id of the county",
+    example: "c7912662-26ea-435c-a1f7-66f52d1440ff",
+    required: true,
+  })
   id: string
 
+  @ApiProperty({ type: String, description: "The name of the country", example: "France", required: true })
   name: string
+
+  @ApiProperty({
+    type: String,
+    description: "The description of the country",
+    example: "France is a country located in Western Europe",
+  })
   description: string
+
+  @ApiProperty({
+    type: [City],
+    description: "The cities of the country",
+    example: [
+      {
+        id: "c7912662-26ea-435c-a1f7-66f52d1440ff",
+        name: "Paris",
+        description: "Paris is the capital city of France",
+        country: {
+          id: "c7912662-26ea-435c-a1f7-66f52d1440ff",
+          name: "France",
+          description: "France is a country located in Western Europe",
+          images: [
+            {
+              url: "https://example.com/image.jpg",
+              type: "jpg",
+              alt: "Eiffel Tower",
+            },
+          ],
+          deleted: false,
+        },
+        images: [
+          {
+            url: "https://example.com/image.jpg",
+            type: "jpg",
+            alt: "Eiffel Tower",
+          },
+        ],
+      },
+    ],
+    required: true,
+    minItems: 1,
+  })
+  @Type(() => City)
   cities: City[]
+
+  @ApiProperty({
+    type: [Image],
+    description: "The images of the country",
+    example: [
+      {
+        url: "https://example.com/image.jpg",
+        type: "jpg",
+        alt: "Eiffel Tower",
+      },
+    ],
+    required: true,
+    minItems: 1,
+  })
+  @Type(() => Image)
   images: Image[]
-  deleted: boolean
 }

--- a/src/modules/countries/dto/country.dto.ts
+++ b/src/modules/countries/dto/country.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
-import { Type } from "class-transformer"
+import { Exclude, Type } from "class-transformer"
 import { City } from "../../cities/entities/city.entity"
 import { Image } from "../../images/entities/image.entity"
 import { Country } from "../entities/country.entity"
@@ -74,4 +74,31 @@ export class CountryDto extends PickType(Country, ["id", "name", "description", 
   })
   @Type(() => Image)
   images: Image[]
+
+  @ApiProperty({
+    type: Boolean,
+    description: "The deleted status",
+    example: false,
+    required: true,
+  })
+  @Exclude()
+  deleted?: boolean
+
+  @ApiProperty({
+    type: Date,
+    description: "The creation date",
+    example: "2021-09-28T00:00:00.000Z",
+    required: true,
+  })
+  @Exclude()
+  createdAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    description: "The update date",
+    example: "2021-09-28T00:00:00.000Z",
+    required: true,
+  })
+  @Exclude()
+  updatedAt?: Date
 }

--- a/src/modules/guide-categories/dto/get-guide-categories-response.dto.ts
+++ b/src/modules/guide-categories/dto/get-guide-categories-response.dto.ts
@@ -9,12 +9,14 @@ export class GetGuideCategoriesResponseDto implements ApiResponse<GuideCategoryD
     required: true,
     example: [
       {
-        key: "c7912662-26ea-435c-a1f7-66f52d1440ff",
-        name: "City Guide",
-        imageUrl: "https://example.com/city-guide.png",
-        deleted: false,
-        createdAt: "2021-08-24T06:00:00.000Z",
-        updatedAt: "2021-08-24T06:00:00.000Z",
+        key: "nature",
+        name: "Nature",
+        imageUrl: "https://example.com/nature.jpg",
+      },
+      {
+        key: "sightseeing",
+        name: "Sightseeing",
+        imageUrl: "https://example.com/sightseeing.jpg",
       },
     ],
   })

--- a/src/modules/guide-categories/dto/get-guide-categories-response.dto.ts
+++ b/src/modules/guide-categories/dto/get-guide-categories-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { ApiError, ApiResponse } from "../../common/types"
+import { GuideCategoryDto } from "./guide-category.dto"
+
+export class GetGuideCategoriesResponseDto implements ApiResponse<GuideCategoryDto[]> {
+  @ApiProperty({
+    type: [GuideCategoryDto],
+    description: "Guide categories",
+    required: true,
+    example: [
+      {
+        key: "c7912662-26ea-435c-a1f7-66f52d1440ff",
+        name: "City Guide",
+        imageUrl: "https://example.com/city-guide.png",
+        deleted: false,
+        createdAt: "2021-08-24T06:00:00.000Z",
+        updatedAt: "2021-08-24T06:00:00.000Z",
+      },
+    ],
+  })
+  data: GuideCategoryDto[]
+
+  @ApiProperty({
+    type: ApiError,
+    description: "Error message",
+    required: false,
+    example: [
+      {
+        message: "Guide categories not found",
+        name: "NotFoundError",
+        stack: `Error: Guide categories not found\n    at Object.<anonymous> (/app/src/modules/guide-categories/guide-categories.controller.ts:40:15)`,
+      },
+    ],
+  })
+  errors: ApiError[] | null
+}

--- a/src/modules/guide-categories/dto/guide-category.dto.ts
+++ b/src/modules/guide-categories/dto/guide-category.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, PickType } from "@nestjs/swagger"
+import { GuideCategory } from "../entities/guide-category.entity"
+
+export class GuideCategoryDto extends PickType(GuideCategory, ["key", "name", "imageUrl"] as const) {
+  @ApiProperty({
+    type: String,
+    description: "The key of the guide category",
+    example: "explore-city",
+    required: true,
+  })
+  key: string
+
+  @ApiProperty({
+    type: String,
+    description: "The name of the guide category",
+    example: "Explore City",
+    required: true,
+  })
+  name: string
+
+  @ApiProperty({
+    type: String,
+    description: "The image URL of the guide category",
+    example: "https://example.com/explore-city.png",
+    required: true,
+  })
+  imageUrl: string
+}

--- a/src/modules/guide-categories/dto/guide-category.dto.ts
+++ b/src/modules/guide-categories/dto/guide-category.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
+import { Exclude } from "class-transformer"
 import { GuideCategory } from "../entities/guide-category.entity"
 
 export class GuideCategoryDto extends PickType(GuideCategory, ["key", "name", "imageUrl"] as const) {
@@ -25,4 +26,28 @@ export class GuideCategoryDto extends PickType(GuideCategory, ["key", "name", "i
     required: true,
   })
   imageUrl: string
+
+  @ApiProperty({
+    type: Boolean,
+    description: "Whether the guide category is deleted",
+    example: false,
+  })
+  @Exclude()
+  deleted?: boolean
+
+  @ApiProperty({
+    type: Date,
+    description: "The date and time the guide category was created",
+    example: "2021-01-01T00:00:00Z",
+  })
+  @Exclude()
+  createdAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    description: "The date and time the guide category was last updated",
+    example: "2021-01-01T00:00:00Z",
+  })
+  @Exclude()
+  updatedAt?: Date
 }

--- a/src/modules/guide-categories/entities/guide-category.entity.ts
+++ b/src/modules/guide-categories/entities/guide-category.entity.ts
@@ -1,0 +1,30 @@
+import { Type } from "class-transformer"
+import { IsString, IsUrl, IsNotEmpty, IsBoolean, IsDate } from "class-validator"
+import { Guide } from "./guide"
+
+export class GuideCategory {
+  @IsString()
+  @IsNotEmpty()
+  key: string
+
+  @IsString()
+  @IsNotEmpty()
+  name: string
+
+  @IsString()
+  @IsUrl()
+  @IsNotEmpty()
+  imageUrl: string
+
+  @Type(() => Guide)
+  guides: Guide[]
+
+  @IsBoolean()
+  deleted: boolean
+
+  @IsDate()
+  createdAt: Date
+
+  @IsDate()
+  updatedAt: Date
+}

--- a/src/modules/guide-categories/entities/guide.ts
+++ b/src/modules/guide-categories/entities/guide.ts
@@ -1,0 +1,3 @@
+import { Guide } from "../../guides/entities/guide.entity"
+
+export { Guide }

--- a/src/modules/guide-categories/guide-categories.controller.spec.ts
+++ b/src/modules/guide-categories/guide-categories.controller.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { getGuideCategoryDtoMock } from "../../test-utils/mocks/guide-category"
+import { MockedLogger } from "../../test-utils/providers"
+import { PrismaModule } from "../prisma/prisma.module"
+import { GuideCategoriesController } from "./guide-categories.controller"
+import { GuideCategoriesService } from "./guide-categories.service"
+
+describe("GuideCategoriesController", () => {
+  let controller: GuideCategoriesController
+  let guideCategoriesService: GuideCategoriesService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [PrismaModule],
+      controllers: [GuideCategoriesController],
+      providers: [GuideCategoriesService, MockedLogger],
+    }).compile()
+
+    controller = module.get<GuideCategoriesController>(GuideCategoriesController)
+    guideCategoriesService = module.get<GuideCategoriesService>(GuideCategoriesService)
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe("Get all guide categories", () => {
+    it("should return an empty array", async () => {
+      jest.spyOn(guideCategoriesService, "findAll").mockReturnValueOnce(Promise.resolve([]))
+
+      const result = await controller.findAll()
+
+      expect(result.data).toEqual([])
+    })
+
+    it("should return an error", async () => {
+      const error = new Error("Test error")
+      jest.spyOn(guideCategoriesService, "findAll").mockRejectedValueOnce(error)
+
+      const result = await controller.findAll()
+
+      expect(result.errors).toHaveLength(1)
+    })
+
+    it("should return guide categories", async () => {
+      const guideCategoryMock = getGuideCategoryDtoMock()
+      jest.spyOn(guideCategoriesService, "findAll").mockReturnValueOnce(Promise.resolve([guideCategoryMock]))
+
+      const result = await controller.findAll()
+
+      expect(result.data).toEqual([guideCategoryMock])
+    })
+  })
+})

--- a/src/modules/guide-categories/guide-categories.controller.ts
+++ b/src/modules/guide-categories/guide-categories.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get } from "@nestjs/common"
+import {
+  ApiBadRequestResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from "@nestjs/swagger"
+import { GetGuideCategoriesResponseDto } from "./dto/get-guide-categories-response.dto"
+import { GuideCategoriesService } from "./guide-categories.service"
+
+@ApiTags("guide-categories")
+@Controller("guide-categories")
+export class GuideCategoriesController {
+  constructor(private readonly guideCategoriesService: GuideCategoriesService) {}
+
+  @Get()
+  @ApiOperation({ summary: "Get all guide categories" })
+  @ApiOkResponse({
+    description: "Guide categories have been successfully received.",
+    type: GetGuideCategoriesResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: "Bad request",
+  })
+  @ApiInternalServerErrorResponse({
+    description: "Internal server error",
+  })
+  async findAll(): Promise<GetGuideCategoriesResponseDto> {
+    try {
+      const result = await this.guideCategoriesService.findAll()
+
+      return {
+        data: result,
+        errors: null,
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        return {
+          data: [],
+          errors: [
+            {
+              message: error.message,
+              name: error.name,
+              stack: error.stack,
+            },
+          ],
+        }
+      }
+    }
+  }
+}

--- a/src/modules/guide-categories/guide-categories.module.ts
+++ b/src/modules/guide-categories/guide-categories.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common"
+import { GuideCategoriesService } from "./guide-categories.service"
+import { GuideCategoriesController } from "./guide-categories.controller"
+
+@Module({
+  controllers: [GuideCategoriesController],
+  providers: [GuideCategoriesService],
+})
+export class GuideCategoriesModule {}

--- a/src/modules/guide-categories/guide-categories.module.ts
+++ b/src/modules/guide-categories/guide-categories.module.ts
@@ -1,9 +1,11 @@
-import { Module } from "@nestjs/common"
+import { Logger, Module } from "@nestjs/common"
+import { PrismaModule } from "../prisma/prisma.module"
 import { GuideCategoriesService } from "./guide-categories.service"
 import { GuideCategoriesController } from "./guide-categories.controller"
 
 @Module({
+  imports: [PrismaModule],
   controllers: [GuideCategoriesController],
-  providers: [GuideCategoriesService],
+  providers: [GuideCategoriesService, Logger],
 })
 export class GuideCategoriesModule {}

--- a/src/modules/guide-categories/guide-categories.service.spec.ts
+++ b/src/modules/guide-categories/guide-categories.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { getGuideCategoryDtoMock, getGuideCategoryMock } from "../../test-utils/mocks/guide-category"
-import { prismaMock, PrismaClientMock } from "../../test-utils/prisma/prisma-instance-mock"
+import { prismaMock, PrismaClientMock } from "../../test-utils/prisma"
 import { MockedLogger } from "../../test-utils/providers"
 import { PrismaService } from "../prisma/prisma.service"
 import { GuideCategoriesService } from "./guide-categories.service"
@@ -46,8 +46,8 @@ describe("GuideCategoriesService", () => {
     })
 
     it("should return an array containing 1 guide category", async () => {
-      const guideCategoryMock = getGuideCategoryMock()
-      const guideCategoryDtoMock = getGuideCategoryDtoMock({ ...guideCategoryMock })
+      const guideCategoryMock = getGuideCategoryMock({ key: "nature", guides: undefined })
+      const guideCategoryDtoMock = getGuideCategoryDtoMock({ key: "nature" })
       prisma.guideCategory.findMany.mockResolvedValueOnce([guideCategoryMock])
 
       const guideCategories = await service.findAll()

--- a/src/modules/guide-categories/guide-categories.service.spec.ts
+++ b/src/modules/guide-categories/guide-categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { GuideCategoriesService } from "./guide-categories.service"
+
+describe("GuideCategoriesService", () => {
+  let service: GuideCategoriesService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GuideCategoriesService],
+    }).compile()
+
+    service = module.get<GuideCategoriesService>(GuideCategoriesService)
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/src/modules/guide-categories/guide-categories.service.spec.ts
+++ b/src/modules/guide-categories/guide-categories.service.spec.ts
@@ -36,7 +36,7 @@ describe("GuideCategoriesService", () => {
 
     it("should throw an error", async () => {
       const error = new Error("Test error")
-      prismaMock.guideCategory.findMany.mockRejectedValueOnce(error)
+      prisma.guideCategory.findMany.mockRejectedValueOnce(error)
 
       try {
         await service.findAll()
@@ -48,7 +48,7 @@ describe("GuideCategoriesService", () => {
     it("should return an array containing 1 guide category", async () => {
       const guideCategoryMock = getGuideCategoryMock()
       const guideCategoryDtoMock = getGuideCategoryDtoMock({ ...guideCategoryMock })
-      prismaMock.guideCategory.findMany.mockResolvedValueOnce([guideCategoryMock])
+      prisma.guideCategory.findMany.mockResolvedValueOnce([guideCategoryMock])
 
       const guideCategories = await service.findAll()
 

--- a/src/modules/guide-categories/guide-categories.service.spec.ts
+++ b/src/modules/guide-categories/guide-categories.service.spec.ts
@@ -1,18 +1,58 @@
 import { Test, TestingModule } from "@nestjs/testing"
+import { getGuideCategoryDtoMock, getGuideCategoryMock } from "../../test-utils/mocks/guide-category"
+import { prismaMock, PrismaClientMock } from "../../test-utils/prisma/prisma-instance-mock"
+import { MockedLogger } from "../../test-utils/providers"
+import { PrismaService } from "../prisma/prisma.service"
 import { GuideCategoriesService } from "./guide-categories.service"
 
 describe("GuideCategoriesService", () => {
   let service: GuideCategoriesService
+  let prisma: PrismaClientMock
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GuideCategoriesService],
-    }).compile()
+      providers: [GuideCategoriesService, PrismaService, MockedLogger],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(prismaMock)
+      .compile()
 
     service = module.get<GuideCategoriesService>(GuideCategoriesService)
+    prisma = prismaMock
   })
 
   it("should be defined", () => {
     expect(service).toBeDefined()
+  })
+
+  describe("Get guide categories", () => {
+    it("should return an empty array of guide categories", async () => {
+      prisma.guideCategory.findMany.mockResolvedValueOnce([])
+
+      const guideCategories = await service.findAll()
+
+      expect(guideCategories).toEqual([])
+    })
+
+    it("should throw an error", async () => {
+      const error = new Error("Test error")
+      prismaMock.guideCategory.findMany.mockRejectedValueOnce(error)
+
+      try {
+        await service.findAll()
+      } catch (error) {
+        expect(error).toEqual(error)
+      }
+    })
+
+    it("should return an array containing 1 guide category", async () => {
+      const guideCategoryMock = getGuideCategoryMock()
+      const guideCategoryDtoMock = getGuideCategoryDtoMock({ ...guideCategoryMock })
+      prismaMock.guideCategory.findMany.mockResolvedValueOnce([guideCategoryMock])
+
+      const guideCategories = await service.findAll()
+
+      expect(guideCategories).toEqual([guideCategoryDtoMock])
+    })
   })
 })

--- a/src/modules/guide-categories/guide-categories.service.ts
+++ b/src/modules/guide-categories/guide-categories.service.ts
@@ -1,9 +1,41 @@
-import { Injectable } from "@nestjs/common"
+import { Injectable, Logger } from "@nestjs/common"
+import { plainToInstance } from "class-transformer"
+import { MAX_PAGE_SIZE } from "../common/constants"
+import { PrismaService } from "../prisma/prisma.service"
 import { GuideCategoryDto } from "./dto/guide-category.dto"
 
 @Injectable()
 export class GuideCategoriesService {
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly logger: Logger,
+  ) {}
+
   async findAll(): Promise<GuideCategoryDto[]> {
-    return []
+    const limit = MAX_PAGE_SIZE
+    const page = 1
+
+    try {
+      const result = await this.prismaService.guideCategory.findMany({
+        skip: (page - 1) * limit,
+        take: limit,
+        where: {
+          deleted: false,
+        },
+      })
+
+      const guideCategoriesDtos = plainToInstance(GuideCategoryDto, result)
+
+      return guideCategoriesDtos
+    } catch (error) {
+      if (error instanceof Error) {
+        this.logger.error(`Error getting guide categories: ${error.toString()}`)
+
+        throw error
+      }
+
+      this.logger.error("An unexpected error occurred while getting guide categories")
+      throw new Error("An error occurred while getting guide categories")
+    }
   }
 }

--- a/src/modules/guide-categories/guide-categories.service.ts
+++ b/src/modules/guide-categories/guide-categories.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from "@nestjs/common"
+import { GuideCategoryDto } from "./dto/guide-category.dto"
+
+@Injectable()
+export class GuideCategoriesService {
+  async findAll(): Promise<GuideCategoryDto[]> {
+    return []
+  }
+}

--- a/src/modules/guide-categories/guide-categories.service.ts
+++ b/src/modules/guide-categories/guide-categories.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common"
 import { plainToInstance } from "class-transformer"
 import { MAX_PAGE_SIZE } from "../common/constants"
+import { getValidPageNumber, getValidPageSize } from "../common/utils/pagination"
 import { PrismaService } from "../prisma/prisma.service"
 import { GuideCategoryDto } from "./dto/guide-category.dto"
 
@@ -12,13 +13,13 @@ export class GuideCategoriesService {
   ) {}
 
   async findAll(): Promise<GuideCategoryDto[]> {
-    const limit = MAX_PAGE_SIZE
-    const page = 1
+    const pageSize = getValidPageSize({ pageSize: MAX_PAGE_SIZE })
+    const page = getValidPageNumber({ page: 1 })
 
     try {
       const result = await this.prismaService.guideCategory.findMany({
-        skip: (page - 1) * limit,
-        take: limit,
+        skip: (page - 1) * pageSize,
+        take: pageSize,
         where: {
           deleted: false,
         },

--- a/src/modules/guides/constants.ts
+++ b/src/modules/guides/constants.ts
@@ -1,3 +1,10 @@
 import { DEFAULT_PAGE_SIZE } from "../common/constants"
 
 export const DEFAULT_GUIDES_PAGE_SIZE = DEFAULT_PAGE_SIZE
+
+export const GUIDE_CATEGORIES_MAX_SIZE = 2
+export const GUIDE_CATEGORIES_MIN_SIZE = 1
+
+export const GUIDE_COUNTRIES_MIN_SIZE = 1
+
+export const GUIDE_CITIES_MIN_SIZE = 1

--- a/src/modules/guides/dto/guide.dto.ts
+++ b/src/modules/guides/dto/guide.dto.ts
@@ -1,12 +1,22 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
-import { Exclude, Type } from "class-transformer"
-import { IsBoolean, IsDate, IsString, IsUUID } from "class-validator"
+import { Type } from "class-transformer"
+import { IsDate, IsString, IsUUID } from "class-validator"
 import { Image } from "../../images/entities/image.entity"
 import { City } from "../entities/city"
 import { Country } from "../entities/country"
+import { GuideCategory } from "../entities/guide-category"
 import { Guide } from "../entities/guide.entity"
 
-export class GuideDto extends PickType(Guide, ["id", "name", "text"] as const) {
+export class GuideDto extends PickType(Guide, [
+  "id",
+  "name",
+  "text",
+  "categories",
+  "primaryImages",
+  "contentImages",
+  "cities",
+  "countries",
+] as const) {
   @ApiProperty({
     type: String,
     description: "The id of the guide",
@@ -33,6 +43,20 @@ export class GuideDto extends PickType(Guide, ["id", "name", "text"] as const) {
   })
   @IsString()
   text: string
+
+  @ApiProperty({
+    type: [GuideCategory],
+    description: "The categories of the guide",
+    example: [
+      {
+        key: "sightseeing",
+        name: "Sightseeing",
+        imageUrl: "https://example.com/image.jpg",
+      },
+    ],
+  })
+  @Type(() => GuideCategory)
+  categories: GuideCategory[]
 
   @ApiProperty({
     type: [Image],
@@ -98,14 +122,4 @@ export class GuideDto extends PickType(Guide, ["id", "name", "text"] as const) {
   })
   @IsDate()
   updatedAt: Date
-
-  @ApiProperty({
-    type: Boolean,
-    description: "Whether the guide has been deleted",
-    example: false,
-    default: false,
-  })
-  @IsBoolean()
-  @Exclude()
-  deleted: boolean
 }

--- a/src/modules/guides/dto/guide.dto.ts
+++ b/src/modules/guides/dto/guide.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
-import { Type } from "class-transformer"
+import { Type, Exclude } from "class-transformer"
 import { IsDate, IsString, IsUUID } from "class-validator"
 import { Image } from "../../images/entities/image.entity"
 import { City } from "../entities/city"
@@ -113,7 +113,8 @@ export class GuideDto extends PickType(Guide, [
     example: "2021-08-01T00:00:00.000Z",
   })
   @IsDate()
-  createdAt: Date
+  @Exclude()
+  createdAt?: Date
 
   @ApiProperty({
     type: Date,
@@ -121,5 +122,9 @@ export class GuideDto extends PickType(Guide, [
     example: "2021-08-01T00:00:00.000Z",
   })
   @IsDate()
-  updatedAt: Date
+  @Exclude()
+  updatedAt?: Date
+
+  @Exclude()
+  deleted?: boolean
 }

--- a/src/modules/guides/dto/update-guide.dto.ts
+++ b/src/modules/guides/dto/update-guide.dto.ts
@@ -1,25 +1,63 @@
 import { ApiProperty, PickType } from "@nestjs/swagger"
-import { ArrayMinSize, IsArray, IsUUID } from "class-validator"
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsString, IsUUID } from "class-validator"
+import {
+  GUIDE_CATEGORIES_MAX_SIZE,
+  GUIDE_CATEGORIES_MIN_SIZE,
+  GUIDE_CITIES_MIN_SIZE,
+  GUIDE_COUNTRIES_MIN_SIZE,
+} from "../constants"
 import { Guide } from "../entities/guide.entity"
 
 export class UpdateGuideDto extends PickType(Guide, ["id", "name", "text", "primaryImages", "contentImages"] as const) {
   @ApiProperty({
     type: [String],
+    description: "The list of primary images ids the guide has",
+    examples: ["9a55ee15-d3b6-464f-85b8-755d314b33c1"],
+  })
+  id: string
+
+  @ApiProperty({
+    type: String,
+    description: "The guide name",
+    example: "My guide",
+  })
+  name: string
+
+  @ApiProperty({
+    type: String,
+    description: "The guide text",
+    example: "This is my guide",
+  })
+  text: string
+
+  @ApiProperty({
+    type: [String],
     description: "The list of cities ids the guide is about",
-    example: ["9a55ee15-d3b6-464f-85b8-755d314b33c1"],
+    examples: ["9a55ee15-d3b6-464f-85b8-755d314b33c1"],
   })
   @IsArray()
   @IsUUID(4, { each: true })
-  @ArrayMinSize(1)
+  @ArrayMinSize(GUIDE_CITIES_MIN_SIZE)
   cities: string[]
 
   @ApiProperty({
     type: [String],
     description: "The list of countries ids the guide is about",
-    example: ["9a55ee15-d3b6-464f-85b8-755d314b33c1"],
+    examples: ["9a55ee15-d3b6-464f-85b8-755d314b33c1"],
   })
   @IsArray()
   @IsUUID(4, { each: true })
-  @ArrayMinSize(1)
+  @ArrayMinSize(GUIDE_COUNTRIES_MIN_SIZE)
   countries: string[]
+
+  @ApiProperty({
+    type: [String],
+    description: "The list of categories keys the guide is about",
+    example: ["photography", "food"],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMinSize(GUIDE_CATEGORIES_MIN_SIZE)
+  @ArrayMaxSize(GUIDE_CATEGORIES_MAX_SIZE)
+  categories: string[]
 }

--- a/src/modules/guides/entities/guide-category.ts
+++ b/src/modules/guides/entities/guide-category.ts
@@ -1,0 +1,3 @@
+import { GuideCategory } from "../../guide-categories/entities/guide-category.entity"
+
+export { GuideCategory }

--- a/src/modules/guides/entities/guide.entity.ts
+++ b/src/modules/guides/entities/guide.entity.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsDate, IsString, IsUUID } from "class-validator"
 import { City } from "./city"
 import { Country } from "./country"
 import { Image } from "./image"
+import { GuideCategory } from "./guide-category"
 
 export class Guide {
   @IsUUID(4, { message: "Invalid UUID" })
@@ -13,6 +14,9 @@ export class Guide {
 
   @IsString()
   text: string
+
+  @Type(() => GuideCategory)
+  categories: GuideCategory[]
 
   @Type(() => Image)
   primaryImages: Image[]

--- a/src/modules/guides/guides.controller.spec.ts
+++ b/src/modules/guides/guides.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { plainToInstance } from "class-transformer"
-import { getGuideMock } from "../../test-utils/mocks/guides"
+import { getGuideDtoMock } from "../../test-utils/mocks/guides"
 import { MockedLogger } from "../../test-utils/providers"
 import { PrismaModule } from "../prisma/prisma.module"
 import { CreateGuideResponseDto } from "./dto/create-guide-response.dto"
@@ -30,7 +30,7 @@ describe("GuidesController", () => {
 
   describe("Create guide", () => {
     it("should create a simple guide", async () => {
-      const guideMock = getGuideMock()
+      const guideMock = getGuideDtoMock()
       const createGuideDto: CreateGuideDto = plainToInstance(CreateGuideDto, guideMock)
       const guideDto: GuideDto = plainToInstance(GuideDto, guideMock)
       const result: CreateGuideResponseDto = {
@@ -56,7 +56,7 @@ describe("GuidesController", () => {
     })
 
     it("should handle guide creation error", async () => {
-      const guideMock = getGuideMock()
+      const guideMock = getGuideDtoMock()
       const createGuideDto: CreateGuideDto = plainToInstance(CreateGuideDto, guideMock)
       const expectedError = new Error("Test error")
       jest.spyOn(guidesService, "create").mockRejectedValueOnce(expectedError)

--- a/src/modules/guides/guides.controller.spec.ts
+++ b/src/modules/guides/guides.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { plainToInstance } from "class-transformer"
-import { getGuideDtoMock } from "../../test-utils/mocks/guides"
+import { getGuideDtoMock } from "../../test-utils/mocks/guide"
 import { MockedLogger } from "../../test-utils/providers"
 import { PrismaModule } from "../prisma/prisma.module"
 import { CreateGuideResponseDto } from "./dto/create-guide-response.dto"

--- a/src/modules/guides/guides.controller.ts
+++ b/src/modules/guides/guides.controller.ts
@@ -54,6 +54,8 @@ export class GuidesController {
   })
   @ApiBody({ type: CreateGuideDto, required: true, description: "The guide to create" })
   async create(@Body() createGuideDto: CreateGuideDto): Promise<CreateGuideResponseDto> {
+    // TODO: Put input validation here
+
     try {
       const creationResult = await this.guidesService.create(createGuideDto)
 

--- a/src/modules/guides/guides.service.spec.ts
+++ b/src/modules/guides/guides.service.spec.ts
@@ -1,21 +1,186 @@
 import { Test, TestingModule } from "@nestjs/testing"
+import { getCityMock } from "../../test-utils/mocks/city"
+import { getCountryMock } from "../../test-utils/mocks/country"
+import { getGuideCategoryMock } from "../../test-utils/mocks/guide-category"
+import { getGuideMock } from "../../test-utils/mocks/guide"
+import { getImageMock } from "../../test-utils/mocks/image"
+import { PrismaClientMock, prismaMock } from "../../test-utils/prisma"
 import { MockedLogger } from "../../test-utils/providers"
+import { PaginationQuery } from "../common/types"
 import { PrismaModule } from "../prisma/prisma.module"
+import { PrismaService } from "../prisma/prisma.service"
 import { GuidesService } from "./guides.service"
 
 describe("GuidesService", () => {
   let service: GuidesService
+  let prisma: PrismaClientMock
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [PrismaModule],
-      providers: [GuidesService, MockedLogger],
-    }).compile()
+      providers: [GuidesService, PrismaService, MockedLogger],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(prismaMock)
+      .compile()
 
     service = module.get<GuidesService>(GuidesService)
+    prisma = prismaMock
   })
 
   it("should be defined", () => {
     expect(service).toBeDefined()
+  })
+
+  describe("Get guides", () => {
+    it("should return an empty array of guides when page size equals 0", async () => {
+      const paginationQuery: PaginationQuery = {
+        pageSize: 0,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([])
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([])
+    })
+
+    it("should return an empty array of guides when page is 0", async () => {
+      const paginationQuery: PaginationQuery = {
+        pageSize: 1,
+        page: 0,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([])
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([])
+    })
+
+    it("should throw an error", async () => {
+      const error = new Error("Test error")
+      prismaMock.guide.findMany.mockRejectedValueOnce(error)
+      const paginationQuery: PaginationQuery = {
+        pageSize: 2,
+        page: 1,
+      }
+
+      try {
+        await service.findAll(paginationQuery)
+      } catch (error) {
+        expect(error).toEqual(error)
+      }
+    })
+
+    it("should return array containing 2 guides", async () => {
+      const guideMock = getGuideMock({
+        id: "1",
+      })
+      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideMock2 = getGuideMock({
+        id: "2",
+      })
+      const guideDtoMock2 = getGuideMock({ ...guideMock2 })
+      const paginationQuery: PaginationQuery = {
+        pageSize: 2,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([guideMock, guideMock2])
+
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([guideDtoMock, guideDtoMock2])
+    })
+
+    it("should return array containing 1 guide with categories", async () => {
+      const guideCategoryMock = getGuideCategoryMock({ key: "category1" })
+      const guideMock = getGuideMock({
+        id: "1",
+        categories: [guideCategoryMock],
+      })
+      const guideDtoMock = getGuideMock({ ...guideMock })
+      const paginationQuery: PaginationQuery = {
+        pageSize: 1,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([guideMock])
+
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([guideDtoMock])
+      expect(guides[0].categories).toEqual([guideCategoryMock])
+    })
+
+    it("should return array containing 1 guide with primary images", async () => {
+      const imageMock = getImageMock()
+      const guideMock = getGuideMock({
+        id: "1",
+        primaryImages: [imageMock],
+      })
+      const guideDtoMock = getGuideMock({ ...guideMock })
+      const paginationQuery: PaginationQuery = {
+        pageSize: 1,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([guideMock])
+
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([guideDtoMock])
+      expect(guides[0].primaryImages[0]).toEqual(imageMock)
+    })
+
+    it("should return array containing 1 guide with content images", async () => {
+      const imageMock = getImageMock()
+      const guideMock = getGuideMock({
+        id: "1",
+        contentImages: [imageMock],
+      })
+      const guideDtoMock = getGuideMock({ ...guideMock })
+      const paginationQuery: PaginationQuery = {
+        pageSize: 1,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([guideMock])
+
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([guideDtoMock])
+      expect(guides[0].contentImages).toEqual(guideDtoMock.contentImages)
+    })
+
+    it("should return array containing 1 guide with countries", async () => {
+      const guideMock = getGuideMock({
+        id: "1",
+        countries: [getCountryMock()],
+      })
+      const guideDtoMock = getGuideMock({ ...guideMock })
+      const paginationQuery: PaginationQuery = {
+        pageSize: 1,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([guideMock])
+
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([guideDtoMock])
+      expect(guides[0].countries).toEqual(guideDtoMock.countries)
+    })
+
+    it("should return array containing 1 guide with cities", async () => {
+      const guideMock = getGuideMock({
+        id: "1",
+        cities: [getCityMock()],
+      })
+      const guideDtoMock = getGuideMock({ ...guideMock })
+      const paginationQuery: PaginationQuery = {
+        pageSize: 1,
+        page: 1,
+      }
+      prisma.guide.findMany.mockResolvedValueOnce([guideMock])
+
+      const guides = await service.findAll(paginationQuery)
+
+      expect(guides).toEqual([guideDtoMock])
+      expect(guides[0].cities).toEqual(guideDtoMock.cities)
+    })
   })
 })

--- a/src/modules/guides/guides.service.spec.ts
+++ b/src/modules/guides/guides.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { getCityMock } from "../../test-utils/mocks/city"
 import { getCountryMock } from "../../test-utils/mocks/country"
 import { getGuideCategoryMock } from "../../test-utils/mocks/guide-category"
-import { getGuideMock } from "../../test-utils/mocks/guide"
+import { getGuideDtoMock, getGuideMock } from "../../test-utils/mocks/guide"
 import { getImageMock } from "../../test-utils/mocks/image"
 import { PrismaClientMock, prismaMock } from "../../test-utils/prisma"
 import { MockedLogger } from "../../test-utils/providers"
@@ -74,11 +74,11 @@ describe("GuidesService", () => {
       const guideMock = getGuideMock({
         id: "1",
       })
-      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideDtoMock = getGuideDtoMock({ id: "1" })
       const guideMock2 = getGuideMock({
         id: "2",
       })
-      const guideDtoMock2 = getGuideMock({ ...guideMock2 })
+      const guideDtoMock2 = getGuideDtoMock({ id: "2" })
       const paginationQuery: PaginationQuery = {
         pageSize: 2,
         page: 1,
@@ -96,7 +96,7 @@ describe("GuidesService", () => {
         id: "1",
         categories: [guideCategoryMock],
       })
-      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideDtoMock = getGuideDtoMock({ id: "1", categories: [guideCategoryMock] })
       const paginationQuery: PaginationQuery = {
         pageSize: 1,
         page: 1,
@@ -115,7 +115,7 @@ describe("GuidesService", () => {
         id: "1",
         primaryImages: [imageMock],
       })
-      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideDtoMock = getGuideDtoMock({ id: "1", primaryImages: [imageMock] })
       const paginationQuery: PaginationQuery = {
         pageSize: 1,
         page: 1,
@@ -134,7 +134,7 @@ describe("GuidesService", () => {
         id: "1",
         contentImages: [imageMock],
       })
-      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideDtoMock = getGuideDtoMock({ id: "1", contentImages: [imageMock] })
       const paginationQuery: PaginationQuery = {
         pageSize: 1,
         page: 1,
@@ -152,7 +152,7 @@ describe("GuidesService", () => {
         id: "1",
         countries: [getCountryMock()],
       })
-      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideDtoMock = getGuideDtoMock({ id: "1", countries: [getCountryMock()] })
       const paginationQuery: PaginationQuery = {
         pageSize: 1,
         page: 1,
@@ -170,7 +170,7 @@ describe("GuidesService", () => {
         id: "1",
         cities: [getCityMock()],
       })
-      const guideDtoMock = getGuideMock({ ...guideMock })
+      const guideDtoMock = getGuideDtoMock({ id: "1", cities: [getCityMock()] })
       const paginationQuery: PaginationQuery = {
         pageSize: 1,
         page: 1,

--- a/src/modules/guides/guides.service.ts
+++ b/src/modules/guides/guides.service.ts
@@ -65,7 +65,6 @@ export class GuidesService {
       }
 
       if (error instanceof Error) {
-        console.error("CreateGuide", error.toString())
         this.logger.error(`Error creating guide: ${error.message}`)
 
         throw error

--- a/src/modules/guides/guides.service.ts
+++ b/src/modules/guides/guides.service.ts
@@ -24,9 +24,13 @@ export class GuidesService {
           name: createGuideDto.name,
           text: createGuideDto.text,
           primaryImages: {
+            // TODO: possibly replace on connect due to the fact the image upload should create an image record
+            // or connectAndCreate at least
             create: createGuideDto.primaryImages,
           },
           contentImages: {
+            // TODO: possibly replace on connect due to the fact the image upload should create an image record
+            // or connectAndCreate at least
             create: createGuideDto?.contentImages,
           },
           countries: {
@@ -40,6 +44,13 @@ export class GuidesService {
             connect: createGuideDto.cities.map(cityId => {
               return {
                 id: cityId,
+              }
+            }),
+          },
+          categories: {
+            connect: createGuideDto.categories.map(categoryKey => {
+              return {
+                key: categoryKey,
               }
             }),
           },

--- a/src/modules/images/dto/image.dto.ts
+++ b/src/modules/images/dto/image.dto.ts
@@ -1,4 +1,8 @@
-import { OmitType, PartialType } from "@nestjs/swagger"
+import { PartialType, PickType } from "@nestjs/swagger"
 import { Image } from "../entities/image.entity"
 
-export class ImageDto extends PartialType(OmitType(Image, ["deleted"] as const)) {}
+export class ImageDto extends PartialType(PickType(Image, ["id", "type", "url"] as const)) {
+  id: string
+  type: string
+  url: string
+}

--- a/src/modules/images/dto/image.dto.ts
+++ b/src/modules/images/dto/image.dto.ts
@@ -1,8 +1,36 @@
-import { PartialType, PickType } from "@nestjs/swagger"
+import { ApiProperty, PartialType, PickType } from "@nestjs/swagger"
+import { Exclude } from "class-transformer"
 import { Image } from "../entities/image.entity"
 
 export class ImageDto extends PartialType(PickType(Image, ["id", "type", "url"] as const)) {
   id: string
   type: string
   url: string
+
+  @ApiProperty({
+    type: Boolean,
+    description: "The deleted status",
+    example: false,
+    required: true,
+  })
+  @Exclude()
+  deleted?: boolean
+
+  @ApiProperty({
+    type: Date,
+    description: "The creation date",
+    example: "2021-09-28T00:00:00.000Z",
+    required: true,
+  })
+  @Exclude()
+  createdAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    description: "The update date",
+    example: "2021-09-28T00:00:00.000Z",
+    required: true,
+  })
+  @Exclude()
+  updatedAt?: Date
 }

--- a/src/modules/images/dto/update-image.dto.ts
+++ b/src/modules/images/dto/update-image.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from "@nestjs/swagger"
-import { UploadImagesDto } from "./upload-images.dto"
-
-export class UpdateImageDto extends PartialType(UploadImagesDto) {}

--- a/src/modules/images/entities/image.entity.ts
+++ b/src/modules/images/entities/image.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger"
 import { Exclude } from "class-transformer"
-import { IsBoolean, IsMimeType, IsOptional, IsString, IsUrl, IsUUID } from "class-validator"
+import { IsBoolean, IsDate, IsMimeType, IsOptional, IsString, IsUrl, IsUUID } from "class-validator"
 
 export class Image {
   @ApiProperty({
@@ -49,6 +49,23 @@ export class Image {
     required: true,
   })
   @IsBoolean()
-  @Exclude()
   deleted: boolean
+
+  @ApiProperty({
+    type: Date,
+    description: "The date the image was created",
+    example: "2022-01-01T00:00:00Z",
+    required: true,
+  })
+  @IsDate()
+  createdAt: Date
+
+  @ApiProperty({
+    type: Date,
+    description: "The date the image was updated",
+    example: "2022-01-01T00:00:00Z",
+    required: true,
+  })
+  @IsDate()
+  updatedAt: Date
 }

--- a/src/modules/images/images.service.ts
+++ b/src/modules/images/images.service.ts
@@ -15,13 +15,14 @@ export class ImagesService {
       const uploadedFilesResult = await this.awsS3Service.uploadFiles(imagesDto.files)
 
       const imageDtos = uploadedFilesResult.map<ImageDto>(result => {
-        return {
-          // TODO: fill necessary fields
-          // id: result.id,
+        const imageDto: ImageDto = {
+          // TODO: Fill fields from result correctly
+          id: null,
+          type: null,
           url: result.url,
-          // type: result.type,
-          // alt: result.alt,
         }
+
+        return imageDto
       })
 
       return imageDtos

--- a/src/modules/prisma/prisma.module.ts
+++ b/src/modules/prisma/prisma.module.ts
@@ -1,8 +1,8 @@
-import { Module } from "@nestjs/common"
+import { Logger, Module } from "@nestjs/common"
 import { PrismaService } from "./prisma.service"
 
 @Module({
-  providers: [PrismaService],
+  providers: [PrismaService, Logger],
   exports: [PrismaService],
 })
 export class PrismaModule {}

--- a/src/modules/prisma/prisma.service.spec.ts
+++ b/src/modules/prisma/prisma.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing"
+import { MockedLogger } from "../../test-utils/providers"
 import { PrismaService } from "./prisma.service"
 
 describe("PrismaService", () => {
@@ -6,7 +7,7 @@ describe("PrismaService", () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PrismaService],
+      providers: [PrismaService, MockedLogger],
     }).compile()
 
     service = module.get<PrismaService>(PrismaService)
@@ -14,5 +15,11 @@ describe("PrismaService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined()
+  })
+
+  it("should call connect to db by triggering onModuleInit hook", async () => {
+    const connectSpy = jest.spyOn(service, "$connect")
+    await service.onModuleInit()
+    expect(connectSpy).toBeCalledTimes(1)
   })
 })

--- a/src/modules/prisma/prisma.service.ts
+++ b/src/modules/prisma/prisma.service.ts
@@ -1,9 +1,19 @@
-import { Injectable, OnModuleInit } from "@nestjs/common"
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common"
 import { PrismaClient } from "@prisma/client"
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
+  constructor(private readonly logger: Logger) {
+    super()
+  }
+
   async onModuleInit() {
-    await this.$connect()
+    try {
+      await this.$connect()
+    } catch (e) {
+      console.error(e)
+      this.logger.error(`Failed to connect to the database: ${e.toString()}`)
+      throw e
+    }
   }
 }

--- a/src/modules/prisma/seed.ts
+++ b/src/modules/prisma/seed.ts
@@ -1,14 +1,32 @@
+import "dotenv/config"
 import { PrismaClient } from "@prisma/client"
-// import { readFileSync } from 'fs';
+import { processGuideCategoriesSeed } from "./seeds/guide-categories"
+
+const env = process.env.NODE_ENV
+const isProduction = env === "production"
 
 const prisma = new PrismaClient()
 
 async function main() {
-  console.log(`Start seeding ...`)
+  console.log(`Start seeding...`)
+  console.log(`Env: ${env}`)
 
-  // DO SOME SEEDING HERE
-  // E.G.
-  // const users = JSON.parse(readFileSync('src/prisma/seeds/users.json', 'utf-8'));
+  if (isProduction) {
+    console.error(`Seeding is not allowed in production.`)
+    return
+  }
+
+  console.log(`Seeding Guide Categories started`)
+  try {
+    const isSuccessful = await processGuideCategoriesSeed(prisma)
+
+    if (!isSuccessful) {
+      console.error(`Error on Guide Categories seeding`)
+    }
+  } catch (error) {
+    console.error(`Error on Guide Categories seeding: ${error}`)
+  }
+  console.log(`Seeding Guide Categories finished`)
 
   console.log(`Seeding finished.`)
 }

--- a/src/modules/prisma/seeds/guide-categories/constants.ts
+++ b/src/modules/prisma/seeds/guide-categories/constants.ts
@@ -1,0 +1,1 @@
+export const GUIDE_CATEGORIES_SEED_PATH = "src/modules/prisma/seeds/guide-categories/guide-categories.json"

--- a/src/modules/prisma/seeds/guide-categories/guide-categories.json
+++ b/src/modules/prisma/seeds/guide-categories/guide-categories.json
@@ -1,0 +1,32 @@
+[
+  {
+    "key": "nature",
+    "name": "Breathtaking Nature",
+    "imageUrl": "https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s="
+  },
+  {
+    "key": "food",
+    "name": "Food Tour",
+    "imageUrl": "https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s="
+  },
+  {
+    "key": "photography",
+    "name": "Best Photo",
+    "imageUrl": "https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s="
+  },
+  {
+    "key": "market",
+    "name": "Market Tour",
+    "imageUrl": "https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s="
+  },
+  {
+    "key": "history",
+    "name": "Historical Tour",
+    "imageUrl": "https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s="
+  },
+  {
+    "key": "shopping",
+    "name": "Shopping Tour",
+    "imageUrl": "https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s="
+  }
+]

--- a/src/modules/prisma/seeds/guide-categories/index.ts
+++ b/src/modules/prisma/seeds/guide-categories/index.ts
@@ -1,0 +1,1 @@
+export { processGuideCategoriesSeed } from "./processor"

--- a/src/modules/prisma/seeds/guide-categories/processor.ts
+++ b/src/modules/prisma/seeds/guide-categories/processor.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from "@prisma/client"
+import { validateSeedInputData, validateSeedPath, extractSeedDataFromFile } from "../utils"
+import { GUIDE_CATEGORIES_SEED_PATH } from "./constants"
+import { schema } from "./schema"
+import { GuideCategoryCreateInput } from "./utils"
+
+export async function processGuideCategoriesSeed(prisma: PrismaClient): Promise<boolean> {
+  const isPathValid = validateSeedPath(GUIDE_CATEGORIES_SEED_PATH)
+
+  if (!isPathValid) {
+    throw new Error(`Invalid seed path: ${GUIDE_CATEGORIES_SEED_PATH}`)
+  }
+
+  const guideCategories = extractSeedDataFromFile<GuideCategoryCreateInput>(GUIDE_CATEGORIES_SEED_PATH)
+
+  const isValid = validateSeedInputData(guideCategories, schema)
+
+  if (!isValid) {
+    throw new Error("Invalid seed data")
+  }
+
+  const { count } = await prisma.guideCategory.createMany({
+    data: guideCategories,
+    skipDuplicates: true,
+  })
+
+  return count > 0
+}

--- a/src/modules/prisma/seeds/guide-categories/schema.ts
+++ b/src/modules/prisma/seeds/guide-categories/schema.ts
@@ -1,0 +1,21 @@
+// How to generate schema correctly:
+// 1. Enable strictNullChecks in tsconfig.json
+// 2. Put JSONSchemaType<YOUR_TYPE> type in schema variable
+// 3. Put satisfies JSONSchemaType<YOUR_TYPE> at the end of schema variable
+// 4. Fix all errors in schema variable
+// 5. Remove satisfies JSONSchemaType<YOUR_TYPE> from schema variable
+// 6. Remove type from schema variable
+// 7. Disable strictNullChecks in tsconfig.json
+
+export const schema = {
+  type: "object",
+  properties: {
+    key: { type: "string" },
+    name: { type: "string" },
+    imageUrl: { type: "string" },
+    deleted: { type: "boolean", nullable: true },
+    createdAt: { type: "string", nullable: true },
+    updatedAt: { type: "string", nullable: true },
+  },
+  required: ["key", "name", "imageUrl"],
+} as const

--- a/src/modules/prisma/seeds/guide-categories/utils.ts
+++ b/src/modules/prisma/seeds/guide-categories/utils.ts
@@ -1,0 +1,7 @@
+import { Prisma } from "@prisma/client"
+import { getSchemaValidator } from "../utils"
+import { schema } from "./schema"
+
+const validate = getSchemaValidator(schema)
+
+export type GuideCategoryCreateInput = Omit<Prisma.GuideCategoryCreateInput, "guides">

--- a/src/modules/prisma/seeds/utils/index.ts
+++ b/src/modules/prisma/seeds/utils/index.ts
@@ -1,0 +1,3 @@
+export { getSchemaValidator, validateSeedInputData } from "./seed-data-validator"
+
+export { extractSeedDataFromFile, validateSeedPath } from "./seed-file"

--- a/src/modules/prisma/seeds/utils/index.ts
+++ b/src/modules/prisma/seeds/utils/index.ts
@@ -1,3 +1,5 @@
 export { getSchemaValidator, validateSeedInputData } from "./seed-data-validator"
 
-export { extractSeedDataFromFile, validateSeedPath } from "./seed-file"
+export { extractSeedDataFromFile } from "./seed-file"
+
+export { validateSeedPath } from "./seed-file-path"

--- a/src/modules/prisma/seeds/utils/seed-data-validator.test.ts
+++ b/src/modules/prisma/seeds/utils/seed-data-validator.test.ts
@@ -1,0 +1,47 @@
+import { getSchemaValidator, validateSeedInputData } from "./seed-data-validator"
+
+describe("seed-data-validator", () => {
+  describe("getSchemaValidator", () => {
+    it("should return null if schema wasn't provided", () => {
+      const validator = getSchemaValidator(null)
+
+      expect(validator).toBeNull()
+    })
+
+    it("should return validate function", () => {
+      const validator = getSchemaValidator({ type: "object" })
+
+      expect(validator).toBeDefined()
+    })
+  })
+
+  describe("validateSeedInputData", () => {
+    it("should return true if data is valid", () => {
+      const data = [{ name: "John Doe" }]
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string", nullable: false },
+        },
+      }
+
+      const isValid = validateSeedInputData(data, schema)
+
+      expect(isValid).toBeTruthy()
+    })
+
+    it("should return false if data is invalid", () => {
+      const data = [{ name: 123 }]
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string", nullable: false },
+        },
+      }
+
+      const isValid = validateSeedInputData(data, schema)
+
+      expect(isValid).toBeFalsy()
+    })
+  })
+})

--- a/src/modules/prisma/seeds/utils/seed-data-validator.ts
+++ b/src/modules/prisma/seeds/utils/seed-data-validator.ts
@@ -1,0 +1,32 @@
+import Ajv, { ValidateFunction } from "ajv"
+
+const ajvInstance = new Ajv({
+  allErrors: true,
+})
+
+export function getSchemaValidator(schema: object): ValidateFunction | null {
+  if (typeof schema !== "object" || schema === null) {
+    return null
+  }
+
+  const validator = ajvInstance.compile(schema)
+
+  return validator
+}
+
+// NOTE: schema has type object because ajv force enabled strictNullChecks in tsconfig.json
+export function validateSeedInputData<TData>(data: TData[], schema: object): boolean {
+  const validate = getSchemaValidator(schema)
+
+  const isValid = data.every(entity => {
+    const valid = validate(entity)
+
+    if (!valid) {
+      console.log(validate.errors)
+    }
+
+    return valid
+  })
+
+  return isValid
+}

--- a/src/modules/prisma/seeds/utils/seed-file-path.test.ts
+++ b/src/modules/prisma/seeds/utils/seed-file-path.test.ts
@@ -1,0 +1,66 @@
+import * as fs from "fs"
+import { validateSeedPath } from "./seed-file-path"
+
+jest.mock("fs", () => {
+  const actualFs = jest.requireActual("fs")
+
+  return {
+    __esModule: false,
+    ...actualFs,
+    existsSync: jest.fn(),
+    lstatSync: jest.fn(),
+    readFileSync: jest.fn(),
+  }
+})
+
+type LstatSyncResult = ReturnType<typeof fs.lstatSync>
+
+describe("seed-file-path", () => {
+  describe("validateSeedPath", () => {
+    let existsSyncMock: jest.MockedFunction<typeof fs.existsSync>
+    let lstatSyncMock: jest.MockedFunction<typeof fs.lstatSync>
+
+    beforeEach(() => {
+      existsSyncMock = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>
+      existsSyncMock.mockReset()
+
+      lstatSyncMock = fs.lstatSync as jest.MockedFunction<typeof fs.lstatSync>
+      lstatSyncMock.mockReset()
+    })
+
+    it("should return true if the path exists and is a file", () => {
+      const path = "path/to/file.txt"
+      existsSyncMock.mockReturnValue(true)
+      lstatSyncMock.mockReturnValueOnce({ isFile: () => true } as LstatSyncResult)
+
+      const result = validateSeedPath(path)
+
+      expect(result).toBe(true)
+      expect(existsSyncMock).toHaveBeenCalledWith(path)
+      expect(lstatSyncMock).toHaveBeenCalledWith(path)
+    })
+
+    it("should return false if the path does not exist", () => {
+      const path = "path/to/file.txt"
+      existsSyncMock.mockReturnValueOnce(false)
+
+      const result = validateSeedPath(path)
+
+      expect(result).toBe(false)
+      expect(existsSyncMock).toHaveBeenCalledWith(path)
+      expect(lstatSyncMock).not.toHaveBeenCalled()
+    })
+
+    it("should return false if the path exists but is not a file", () => {
+      const path = "path/to/file"
+      existsSyncMock.mockReturnValue(true)
+      lstatSyncMock.mockReturnValue({ isFile: () => false } as LstatSyncResult)
+
+      const result = validateSeedPath(path)
+
+      expect(result).toBe(false)
+      expect(existsSyncMock).toHaveBeenCalledWith(path)
+      expect(lstatSyncMock).toHaveBeenCalledWith(path)
+    })
+  })
+})

--- a/src/modules/prisma/seeds/utils/seed-file-path.ts
+++ b/src/modules/prisma/seeds/utils/seed-file-path.ts
@@ -1,0 +1,5 @@
+import { existsSync, lstatSync } from "fs"
+
+export function validateSeedPath(path: string): boolean {
+  return existsSync(path) && lstatSync(path).isFile()
+}

--- a/src/modules/prisma/seeds/utils/seed-file.test.ts
+++ b/src/modules/prisma/seeds/utils/seed-file.test.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs"
+import { extractSeedDataFromFile } from "./seed-file"
+import { validateSeedPath } from "./seed-file-path"
+
+jest.mock("./seed-file-path", () => {
+  return {
+    __esModule: true,
+    validateSeedPath: jest.fn(),
+  }
+})
+
+jest.mock("fs", () => {
+  const actualFs = jest.requireActual("fs")
+
+  return {
+    __esModule: false,
+    ...actualFs,
+    existsSync: jest.fn(),
+    lstatSync: jest.fn(),
+    readFileSync: jest.fn(),
+  }
+})
+
+describe("seed-file", () => {
+  let validateSeedPathMock: jest.MockedFunction<typeof validateSeedPath>
+
+  beforeEach(() => {
+    validateSeedPathMock = validateSeedPath as jest.MockedFunction<typeof validateSeedPath>
+    validateSeedPathMock.mockReset()
+  })
+
+  describe("extractSeedDataFromFile", () => {
+    let readFileSyncMock: jest.MockedFunction<typeof fs.readFileSync>
+
+    beforeEach(() => {
+      readFileSyncMock = fs.readFileSync as jest.MockedFunction<typeof fs.readFileSync>
+      readFileSyncMock.mockReset()
+    })
+
+    it("should throw an error if the path is invalid", () => {
+      const path = "path/to/file.txt"
+      validateSeedPathMock.mockReturnValueOnce(false)
+
+      expect(() => extractSeedDataFromFile(path)).toThrowError(`Invalid seed file path: ${path}`)
+      expect(readFileSyncMock).not.toHaveBeenCalled()
+    })
+
+    it("should return the parsed data from the file", () => {
+      const path = "path/to/file.txt"
+      const fileData = "[]"
+      validateSeedPathMock.mockReturnValueOnce(true)
+      readFileSyncMock.mockReturnValueOnce(fileData)
+
+      const result = extractSeedDataFromFile(path)
+
+      expect(result).toEqual([])
+      expect(readFileSyncMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/modules/prisma/seeds/utils/seed-file.ts
+++ b/src/modules/prisma/seeds/utils/seed-file.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "fs"
+import { validateSeedPath } from "./seed-file-path"
+
+export function extractSeedDataFromFile<T>(fileLocation: string): T[] {
+  if (!validateSeedPath(fileLocation)) {
+    throw new Error(`Invalid seed file path: ${fileLocation}`)
+  }
+
+  const fileData = readFileSync(fileLocation, "utf-8")
+  const data: T[] = JSON.parse(fileData)
+
+  return data
+}

--- a/src/test-utils/mocks/city.ts
+++ b/src/test-utils/mocks/city.ts
@@ -1,0 +1,46 @@
+import { CityDto } from "../../modules/cities/dto/city.dto"
+import { City } from "../../modules/cities/entities/city.entity"
+import { getImageMock } from "./image"
+
+export function getCityMock(overrides: Partial<City> = {}): City {
+  return {
+    id: "city-1",
+    name: "Paris",
+    description: "The capital of France",
+    country: {
+      id: "country-1",
+      name: "France",
+      description: "A country in Europe",
+      cities: [],
+      images: [],
+      deleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    images: [getImageMock()],
+    deleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function getCityDtoMock(overrides: Partial<CityDto> = {}): CityDto {
+  return {
+    id: "city-dto-1",
+    name: "Paris",
+    description: "The capital of France",
+    country: {
+      id: "country-1",
+      name: "France",
+      description: "A country in Europe",
+      cities: [],
+      images: [],
+      deleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    images: [],
+    ...overrides,
+  }
+}

--- a/src/test-utils/mocks/country.ts
+++ b/src/test-utils/mocks/country.ts
@@ -1,0 +1,29 @@
+import { CountryDto } from "../../modules/countries/dto/country.dto"
+import { Country } from "../../modules/countries/entities/country.entity"
+import { getCityMock } from "./city"
+import { getImageMock } from "./image"
+
+export function getCountryMock(overrides: Partial<Country> = {}): Country {
+  return {
+    id: "country-1",
+    name: "France",
+    description: "A country in Europe",
+    cities: [getCityMock()],
+    images: [getImageMock()],
+    deleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function getCountryDtoMock(overrides: Partial<CountryDto> = {}): CountryDto {
+  return {
+    id: "country-dto-1",
+    name: "France",
+    description: "A country in Europe",
+    images: [getImageMock()],
+    cities: [getCityMock()],
+    ...overrides,
+  }
+}

--- a/src/test-utils/mocks/guide-category.ts
+++ b/src/test-utils/mocks/guide-category.ts
@@ -1,0 +1,24 @@
+import { GuideCategoryDto } from "../../modules/guide-categories/dto/guide-category.dto"
+import { GuideCategory } from "../../modules/guide-categories/entities/guide-category.entity"
+
+export function getGuideCategoryMock(overrides: Partial<GuideCategory> = {}): GuideCategory {
+  return {
+    key: "explore-city",
+    name: "Explore City",
+    imageUrl: "https://example.com/explore-city.png",
+    guides: [],
+    deleted: false,
+    createdAt: new Date("2021-01-01T00:00:00Z"),
+    updatedAt: new Date("2021-01-01T00:00:00Z"),
+    ...overrides,
+  }
+}
+
+export function getGuideCategoryDtoMock(overrides: Partial<GuideCategoryDto> = {}): GuideCategoryDto {
+  return {
+    key: "explore-city",
+    name: "Explore City",
+    imageUrl: "https://example.com/explore-city.png",
+    ...overrides,
+  }
+}

--- a/src/test-utils/mocks/guide-category.ts
+++ b/src/test-utils/mocks/guide-category.ts
@@ -3,8 +3,8 @@ import { GuideCategory } from "../../modules/guide-categories/entities/guide-cat
 
 export function getGuideCategoryMock(overrides: Partial<GuideCategory> = {}): GuideCategory {
   return {
-    key: "explore-city",
-    name: "Explore City",
+    key: "nature",
+    name: "Nature",
     imageUrl: "https://example.com/explore-city.png",
     guides: [],
     deleted: false,
@@ -16,8 +16,8 @@ export function getGuideCategoryMock(overrides: Partial<GuideCategory> = {}): Gu
 
 export function getGuideCategoryDtoMock(overrides: Partial<GuideCategoryDto> = {}): GuideCategoryDto {
   return {
-    key: "explore-city",
-    name: "Explore City",
+    key: "nature",
+    name: "Nature",
     imageUrl: "https://example.com/explore-city.png",
     ...overrides,
   }

--- a/src/test-utils/mocks/guide.ts
+++ b/src/test-utils/mocks/guide.ts
@@ -28,8 +28,6 @@ export function getGuideDtoMock(overrides: Partial<GuideDto> = {}): GuideDto {
     contentImages: [],
     cities: [],
     countries: [],
-    updatedAt: new Date("2021-01-01T00:00:00Z"),
-    createdAt: new Date("2021-01-01T00:00:00Z"),
     ...overrides,
   }
 }

--- a/src/test-utils/mocks/guide.ts
+++ b/src/test-utils/mocks/guide.ts
@@ -1,3 +1,4 @@
+import { CreateGuideDto } from "../../modules/guides/dto/create-guide.dto"
 import { GuideDto } from "../../modules/guides/dto/guide.dto"
 import { Guide } from "../../modules/guides/entities/guide.entity"
 
@@ -28,6 +29,19 @@ export function getGuideDtoMock(overrides: Partial<GuideDto> = {}): GuideDto {
     contentImages: [],
     cities: [],
     countries: [],
+    ...overrides,
+  }
+}
+
+export function getCreateGuideDtoMock(overrides: Partial<CreateGuideDto> = {}): CreateGuideDto {
+  return {
+    name: "Test Guide",
+    text: "This is a test guide",
+    categories: [],
+    cities: [],
+    countries: [],
+    primaryImages: [],
+    contentImages: [],
     ...overrides,
   }
 }

--- a/src/test-utils/mocks/guide.ts
+++ b/src/test-utils/mocks/guide.ts
@@ -3,9 +3,10 @@ import { Guide } from "../../modules/guides/entities/guide.entity"
 
 export function getGuideMock(overrides: Partial<Guide> = {}): Guide {
   return {
-    id: "1",
+    id: "guide-1",
     name: "Test Guide",
     text: "This is a test guide",
+    categories: [],
     primaryImages: [],
     contentImages: [],
     cities: [],
@@ -19,16 +20,16 @@ export function getGuideMock(overrides: Partial<Guide> = {}): Guide {
 
 export function getGuideDtoMock(overrides: Partial<GuideDto> = {}): GuideDto {
   return {
-    id: "1",
+    id: "guide-dto-1",
     name: "Test Guide",
     text: "This is a test guide",
+    categories: [],
     primaryImages: [],
     contentImages: [],
     cities: [],
     countries: [],
     updatedAt: new Date("2021-01-01T00:00:00Z"),
     createdAt: new Date("2021-01-01T00:00:00Z"),
-    deleted: false,
     ...overrides,
   }
 }

--- a/src/test-utils/mocks/guides.ts
+++ b/src/test-utils/mocks/guides.ts
@@ -1,10 +1,14 @@
-import { Guide } from "@prisma/client"
+import { Guide } from "../../modules/guides/entities/guide.entity"
 
 export function getGuideMock(overrides: Partial<Guide> = {}): Guide {
   return {
     id: "1",
     name: "Test Guide",
     text: "This is a test guide",
+    primaryImages: [],
+    contentImages: [],
+    cities: [],
+    countries: [],
     updatedAt: new Date("2021-01-01T00:00:00Z"),
     createdAt: new Date("2021-01-01T00:00:00Z"),
     deleted: false,

--- a/src/test-utils/mocks/guides.ts
+++ b/src/test-utils/mocks/guides.ts
@@ -1,6 +1,23 @@
+import { GuideDto } from "../../modules/guides/dto/guide.dto"
 import { Guide } from "../../modules/guides/entities/guide.entity"
 
 export function getGuideMock(overrides: Partial<Guide> = {}): Guide {
+  return {
+    id: "1",
+    name: "Test Guide",
+    text: "This is a test guide",
+    primaryImages: [],
+    contentImages: [],
+    cities: [],
+    countries: [],
+    updatedAt: new Date("2021-01-01T00:00:00Z"),
+    createdAt: new Date("2021-01-01T00:00:00Z"),
+    deleted: false,
+    ...overrides,
+  }
+}
+
+export function getGuideDtoMock(overrides: Partial<GuideDto> = {}): GuideDto {
   return {
     id: "1",
     name: "Test Guide",

--- a/src/test-utils/mocks/image.ts
+++ b/src/test-utils/mocks/image.ts
@@ -1,0 +1,24 @@
+import { ImageDto } from "../../modules/images/dto/image.dto"
+import { Image } from "../../modules/images/entities/image.entity"
+
+export function getImageMock(overrides: Partial<Image> = {}): Image {
+  return {
+    id: "image-1",
+    url: "https://example.com/image.jpg",
+    type: "jpg",
+    alt: "Test Image",
+    deleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+export function getImageDtoMock(overrides: Partial<ImageDto> = {}): ImageDto {
+  return {
+    id: "image-dto-1",
+    url: "https://example.com/image.jpg",
+    type: "jpg",
+    ...overrides,
+  }
+}

--- a/src/test-utils/prisma/client.ts
+++ b/src/test-utils/prisma/client.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client"
+
+const prisma = new PrismaClient()
+
+export default prisma

--- a/src/test-utils/prisma/index.ts
+++ b/src/test-utils/prisma/index.ts
@@ -1,0 +1,1 @@
+export { PrismaClientMock, prismaMock } from "./prisma-instance-mock"

--- a/src/test-utils/prisma/prisma-instance-mock.ts
+++ b/src/test-utils/prisma/prisma-instance-mock.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from "@prisma/client"
+import { mockDeep, mockReset, DeepMockProxy } from "jest-mock-extended"
+
+jest.mock("./client", () => ({
+  __esModule: true,
+  default: mockDeep<PrismaClient>(),
+}))
+
+beforeEach(() => {
+  mockReset(prismaMock)
+})
+
+export type PrismaClientMock = DeepMockProxy<{
+  // this is needed to resolve the issue with circular types definition
+  // https://github.com/prisma/prisma/issues/10203
+  [K in keyof PrismaClient]: Omit<PrismaClient[K], "groupBy">
+}>
+
+export const prismaMock = mockDeep<PrismaClient>() as unknown as PrismaClientMock

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "noImplicitAny": true,
     "strictBindCallApply": true,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": false
   }
 }


### PR DESCRIPTION
### Github issue

- Issue URL: #36 

### Description

- Extended `how-to-docker` doc
- Added `how-to-prisma` doc
- Added support for mocking prisma instance correctly
- Added one more extension of test files `*.test.ts`
- Extended scrips with `prisma:seed`
- Added `ajv` package to fulfill validation based on schema in seeds
- Added db migrations to add guide categories
- Updated prisma schema with `GuideCategory` table and related fields in other models
- Improved swagger docs
- Made shared functions for pagination validation
- Covered some modules with unit tests
- Implemented guide categories service and endpoint
- Added logging into prisma service
- Added guide categories seeding

### Checklist

- [x] Code compiles correctly
- [x] Extended the README / documentation, if necessary
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Test (`npm run test`) has passed locally
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [x] Followed project coding standards

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

-

### What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-

### Does this introduce a breaking change?

- [x] Yes
- [ ] No

### Demo (After) (e.g. screenshots, Gifs, Videos, link to demo)

**Guide categories in guide creation body**
![image](https://github.com/voyageglobal/voyage-backend/assets/19875209/a8c79403-7d1c-4dbd-8590-c1cf7db0c918)

**Guide categories in guide creation result**
![image](https://github.com/voyageglobal/voyage-backend/assets/19875209/a5b3b789-7b01-4e66-b8df-336d4574d011)

**Guide categories get endpoint**
![image](https://github.com/voyageglobal/voyage-backend/assets/19875209/d031aa67-6667-4f6a-aa4d-cb285667e271)



### Demo (Before)

-   