### PR TITLE
Retrieve only cities containing guides

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -6,7 +6,10 @@
     "^.+\\.(t|j)s$": "ts-jest"
   },
   "collectCoverageFrom": ["**/*.(t|j)s"],
-  "coverageDirectory": "../coverage",
   "testEnvironment": "node",
-  "setupFilesAfterEnv": ["<rootDir>/test-utils/prisma/prisma-instance-mock.ts"]
+  "setupFilesAfterEnv": ["<rootDir>/test-utils/prisma/prisma-instance-mock.ts"],
+  "coverageDirectory": "../coverage",
+  "coveragePathIgnorePatterns": [
+    "<rootDir>/test-utils/"
+  ]
 }

--- a/src/modules/cities/cities.controller.spec.ts
+++ b/src/modules/cities/cities.controller.spec.ts
@@ -1,8 +1,14 @@
+import { NotFoundException } from "@nestjs/common"
 import { Test, TestingModule } from "@nestjs/testing"
+import { getCityDtoMock } from "../../test-utils/mocks/city"
 import { MockedLogger } from "../../test-utils/providers"
+import { PageDto } from "../common/types"
 import { PrismaModule } from "../prisma/prisma.module"
 import { CitiesController } from "./cities.controller"
 import { CitiesService } from "./cities.service"
+import { CityDto } from "./dto/city.dto"
+import { CitiesSortOrder } from "./dto/get-cities-query.dto"
+import { GetCityResponseDto } from "./dto/get-city-response.dto"
 
 describe("CitiesController", () => {
   let controller: CitiesController
@@ -21,5 +27,82 @@ describe("CitiesController", () => {
 
   it("should be defined", () => {
     expect(controller).toBeDefined()
+  })
+
+  describe("Get city by id", () => {
+    it("should return city by id", async () => {
+      const cityMock = getCityDtoMock({
+        id: "1",
+      })
+      const expectedResult: GetCityResponseDto = {
+        data: cityMock,
+        errors: null,
+      }
+      jest.spyOn(citiesService, "findOne").mockReturnValueOnce(Promise.resolve(cityMock))
+
+      const result = await controller.findOne("1")
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it("should throw error when city wasn't found", async () => {
+      jest.spyOn(citiesService, "findOne").mockReturnValueOnce(Promise.resolve(null))
+
+      expect.assertions(1)
+      try {
+        await controller.findOne("1")
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException)
+      }
+    })
+
+    it("should return object containing error", async () => {
+      jest.spyOn(citiesService, "findOne").mockRejectedValueOnce(new Error("Unexpected error"))
+
+      const result = await controller.findOne("1")
+
+      expect(result.data).toBeNull()
+      expect(result.errors).toHaveLength(1)
+    })
+  })
+
+  describe("Get cities", () => {
+    it("should return cities", async () => {
+      const citiesPage: PageDto<CityDto> = {
+        items: [getCityDtoMock()],
+        hasMore: false,
+        page: 1,
+        pageSize: 10,
+        total: 1,
+      }
+      jest.spyOn(citiesService, "findAll").mockReturnValueOnce(Promise.resolve(citiesPage))
+
+      const result = await controller.findAll({
+        page: 1,
+        onlyWithGuides: false,
+        pageSize: 10,
+        sortOrder: CitiesSortOrder.NAME_ASC,
+      })
+
+      expect(result.data.page).toEqual(1)
+      expect(result.data.pageSize).toEqual(10)
+      expect(result.data.total).toEqual(1)
+      expect(result.data.items).toHaveLength(1)
+      expect(result.data.items).toContainEqual(citiesPage.items[0])
+    })
+
+    it("should return object containing error", async () => {
+      jest.spyOn(citiesService, "findAll").mockRejectedValueOnce(new Error("Unexpected error"))
+
+      const result = await controller.findAll({
+        page: 1,
+        sortOrder: CitiesSortOrder.NAME_ASC,
+        onlyWithGuides: false,
+        pageSize: 10,
+      })
+
+      expect(result.data).toBeNull()
+      expect(result.errors).toHaveLength(1)
+    })
   })
 })

--- a/src/modules/cities/cities.controller.ts
+++ b/src/modules/cities/cities.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, NotFoundException, Param, Query, ValidationPipe } from "@nestjs/common"
+import { Controller, Get, NotFoundException, Param, ParseBoolPipe, Query, ValidationPipe } from "@nestjs/common"
 import {
   ApiBadRequestResponse,
   ApiInternalServerErrorResponse,
@@ -45,6 +45,14 @@ export class CitiesController {
       CitiesSortOrder.NAME_DESC,
     ],
     description: "Sort order",
+  })
+  @ApiQuery({
+    name: "onlyWithGuides",
+    required: false,
+    type: Boolean,
+    example: true,
+    description: "Only cities with guides",
+    allowEmptyValue: true,
   })
   @ApiOkResponse({
     type: GetCitiesResponseDto,

--- a/src/modules/cities/cities.service.spec.ts
+++ b/src/modules/cities/cities.service.spec.ts
@@ -1,21 +1,118 @@
 import { Test, TestingModule } from "@nestjs/testing"
+import { getCityDtoMock, getPrismaCityMock } from "../../test-utils/mocks/city"
+import { PrismaClientMock, prismaMock } from "../../test-utils/prisma"
 import { MockedLogger } from "../../test-utils/providers"
 import { PrismaModule } from "../prisma/prisma.module"
+import { PrismaService } from "../prisma/prisma.service"
 import { CitiesService } from "./cities.service"
+import { CitiesSortOrder } from "./dto/get-cities-query.dto"
 
 describe("CitiesService", () => {
   let service: CitiesService
+  let prisma: PrismaClientMock
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [PrismaModule],
-      providers: [CitiesService, MockedLogger],
-    }).compile()
+      providers: [CitiesService, PrismaService, MockedLogger],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(prismaMock)
+      .compile()
 
     service = module.get<CitiesService>(CitiesService)
+    prisma = prismaMock as unknown as PrismaClientMock
   })
 
   it("should be defined", () => {
     expect(service).toBeDefined()
+  })
+
+  describe("findAll", () => {
+    it("should return a list of cities", async () => {
+      const cityDtoMock = getCityDtoMock()
+      const prismaCityMock = getPrismaCityMock({ id: cityDtoMock.id, name: cityDtoMock.name })
+
+      prisma.$transaction.mockResolvedValue([[prismaCityMock], 1])
+      prisma.city.findMany.mockResolvedValue([prismaCityMock])
+      prisma.city.count.mockResolvedValue(1)
+
+      const citiesPage = await service.findAll({
+        pageSize: 10,
+        sortOrder: CitiesSortOrder.NAME_ASC,
+        onlyWithGuides: false,
+        page: 1,
+      })
+
+      expect(citiesPage.total).toEqual(1)
+      expect(citiesPage.page).toEqual(1)
+      expect(citiesPage.items).toHaveLength(1)
+      expect(citiesPage.items[0].id).toEqual(cityDtoMock.id)
+      expect(citiesPage.items[0].name).toEqual(cityDtoMock.name)
+    })
+
+    it("should return a list of cities with guides", async () => {
+      const cityDtoMock = getCityDtoMock()
+      const prismaCityMock = getPrismaCityMock({ id: cityDtoMock.id, name: cityDtoMock.name })
+
+      prisma.$transaction.mockResolvedValue([[prismaCityMock], 1])
+      prisma.city.findMany.mockResolvedValue([prismaCityMock])
+      prisma.city.count.mockResolvedValue(1)
+
+      const cities = await service.findAll({
+        pageSize: 10,
+        sortOrder: CitiesSortOrder.NAME_ASC,
+        onlyWithGuides: true,
+        page: 1,
+      })
+
+      expect(cities.items).toHaveLength(1)
+      expect(cities.items[0].id).toEqual(cityDtoMock.id)
+      expect(cities.items[0].name).toEqual(cityDtoMock.name)
+    })
+
+    it("should throw an error if prisma fails", async () => {
+      prisma.$transaction.mockRejectedValue(new Error("Prisma error"))
+
+      expect.assertions(1)
+      try {
+        await service.findAll({
+          pageSize: 10,
+          page: 1,
+          onlyWithGuides: false,
+          sortOrder: CitiesSortOrder.NAME_ASC,
+        })
+        expect(true).toBe(false)
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+      }
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a city", async () => {
+      const cityDtoMock = getCityDtoMock({ id: "1" })
+      const prismaCityMock = getPrismaCityMock({ id: cityDtoMock.id, name: cityDtoMock.name })
+      prisma.city.findUnique.mockResolvedValue(prismaCityMock)
+
+      const city = await service.findOne(prismaCityMock.id)
+
+      expect(city.id).toEqual(cityDtoMock.id)
+      expect(city.name).toEqual(cityDtoMock.name)
+    })
+
+    it("should return null if city not found", async () => {
+      prisma.city.findUnique.mockResolvedValue(null)
+
+      const city = await service.findOne("1")
+
+      expect(city).toBeNull()
+    })
+
+    it("should throw an error if prisma fails", async () => {
+      prisma.city.findUnique.mockRejectedValue(new Error("Prisma error"))
+
+      await expect(service.findOne("1")).rejects.toThrowError()
+    })
   })
 })

--- a/src/modules/cities/cities.service.ts
+++ b/src/modules/cities/cities.service.ts
@@ -18,6 +18,7 @@ export class CitiesService {
     const pageSize = getValidPageSize({ pageSize: query?.pageSize })
     const page = getValidPageNumber({ page: query?.page })
     const orderBy = getCitiesQueryOrderBy(query.sortOrder)
+    const onlyWithGuides = query.onlyWithGuides
 
     try {
       const [results, total] = await this.prismaService.$transaction([
@@ -30,12 +31,26 @@ export class CitiesService {
           take: pageSize,
           where: {
             deleted: false,
+            ...(onlyWithGuides && {
+              guides: {
+                some: {
+                  deleted: false,
+                },
+              },
+            }),
           },
           orderBy: orderBy,
         }),
         this.prismaService.city.count({
           where: {
             deleted: false,
+            ...(onlyWithGuides && {
+              guides: {
+                some: {
+                  deleted: false,
+                },
+              },
+            }),
           },
         }),
       ])

--- a/src/modules/cities/dto/get-cities-query.dto.ts
+++ b/src/modules/cities/dto/get-cities-query.dto.ts
@@ -1,5 +1,5 @@
-import { Type } from "class-transformer"
-import { IsEnum, IsInt, IsString } from "class-validator"
+import { Transform, Type } from "class-transformer"
+import { IsBoolean, IsEnum, IsInt, IsString } from "class-validator"
 import { PaginationQuery } from "../../common/types"
 
 export enum CitiesSortOrder {
@@ -22,4 +22,13 @@ export class GetCitiesQueryDto implements PaginationQuery {
   @IsEnum(CitiesSortOrder)
   @Type(() => String)
   sortOrder: CitiesSortOrder = CitiesSortOrder.NAME_ASC
+
+  @IsBoolean()
+  @Transform(({ value }) => {
+    if (typeof value === "boolean") return value
+    if (typeof value === "string") return value === "true"
+
+    return false
+  })
+  onlyWithGuides: boolean
 }

--- a/src/test-utils/mocks/city.ts
+++ b/src/test-utils/mocks/city.ts
@@ -1,6 +1,7 @@
 import { CityDto } from "../../modules/cities/dto/city.dto"
 import { City } from "../../modules/cities/entities/city.entity"
 import { getImageMock } from "./image"
+import { City as PrismaCity } from "@prisma/client"
 
 export function getCityMock(overrides: Partial<City> = {}): City {
   return {
@@ -42,7 +43,20 @@ export function getCityDtoMock(overrides: Partial<CityDto> = {}): CityDto {
       createdAt: new Date(),
       updatedAt: new Date(),
     },
-    images: [],
+    images: [getImageMock()],
+    ...overrides,
+  }
+}
+
+export function getPrismaCityMock(overrides: Partial<PrismaCity> = {}): PrismaCity {
+  return {
+    id: "city-1",
+    name: "Paris",
+    description: "The capital of France",
+    countryId: "country-1",
+    deleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
     ...overrides,
   }
 }

--- a/src/test-utils/prisma/prisma-instance-mock.ts
+++ b/src/test-utils/prisma/prisma-instance-mock.ts
@@ -10,10 +10,14 @@ beforeEach(() => {
   mockReset(prismaMock)
 })
 
-export type PrismaClientMock = DeepMockProxy<{
-  // this is needed to resolve the issue with circular types definition
-  // https://github.com/prisma/prisma/issues/10203
-  [K in keyof PrismaClient]: Omit<PrismaClient[K], "groupBy">
-}>
+export type PrismaClientMock = DeepMockProxy<
+  {
+    // this is needed to resolve the issue with circular types definition
+    // https://github.com/prisma/prisma/issues/10203
+    [K in keyof PrismaClient]: Omit<PrismaClient[K], "groupBy">
+  } & {
+    $transaction: DeepMockProxy<PrismaClient["$transaction"]>
+  }
+>
 
 export const prismaMock = mockDeep<PrismaClient>() as unknown as PrismaClientMock


### PR DESCRIPTION
### Github issue

- Issue URL: #70 

### Description

- Add support of query param to retrieve only cities containing guides
- Add unit tests for cities controller and service

### Checklist

- [ ] Code compiles correctly
- [ ] Extended the README / documentation, if necessary
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Test (`npm run test`) has passed locally
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures
- [ ] Followed project coding standards

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

-

### What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Demo (After) (e.g. screenshots, Gifs, Videos, link to demo)

- [ ] Include both desktop and mobile demo if applicable

### Demo (Before)

- [ ] Include both desktop and mobile demo if applicable